### PR TITLE
Quit QOL Change

### DIFF
--- a/bot/cogs/register.py
+++ b/bot/cogs/register.py
@@ -88,7 +88,7 @@ class RegisterCog(commands.Cog, name='register'):
             await display.NO_RULE.send(ctx, f"={ctx.command.name}", cfg.channels["rules"])
             return
         if player.active:
-            await display.AWAY_BLOCKED.send(ctx, ping=True)
+            await display.AWAY_BLOCKED.send(ctx)
             return
         if player.is_lobbied:
             lobby.remove_from_lobby(player)

--- a/bot/cogs/register.py
+++ b/bot/cogs/register.py
@@ -9,6 +9,7 @@ import classes
 
 # Custom modules
 import modules.config as cfg
+import modules.lobby as lobby
 from display.strings import AllStrings as display
 from modules.tools import is_al_num
 from modules.tools import UnexpectedError
@@ -86,6 +87,11 @@ class RegisterCog(commands.Cog, name='register'):
         if not player:
             await display.NO_RULE.send(ctx, f"={ctx.command.name}", cfg.channels["rules"])
             return
+        if player.active:
+            await display.AWAY_BLOCKED.send(ctx, ping=True)
+            return
+        if player.is_lobbied:
+            lobby.remove_from_lobby(player)
         player.is_away = True
         await display.AWAY_GONE.send(ctx, player.mention)
         await role_update(player)

--- a/bot/display/strings.py
+++ b/bot/display/strings.py
@@ -29,6 +29,7 @@ class AllStrings(Enum):
 
     AWAY_BACK = Message("{} Welcome back!")
     AWAY_GONE = Message("Roles removed for {}", ping=False)
+    AWAY_BLOCKED = Message("You can't quit while you're playing a match!")
 
     LB_ALREADY_IN = Message("You are already in queue!")
     LB_IN_MATCH = Message("You are already in a match!")


### PR DESCRIPTION
Quick pull request to address Rapid's suggestion in #pog-feedback (https://discord.com/channels/207168033918025729/742045837340704781/1093323245706555422)

Does a simple check if a player is lobbied, and removes them from the lobby if so.  
Also ensures player cannot =quit if they are in a match.

Note this is a quick fairly self explanatory change, so I did not build a local dev environment to test it.