### PR TITLE
POG Account Block usage control

### DIFF
--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -277,11 +277,10 @@ class AdminCog(commands.Cog, name='admin'):
                 return
             lobby.set_lobby_accounts_enabled(False)
             removed = []
-            for p_id in lobby.get_all_ids_in_lobby():
-                player = Player.get(p_id)
-                if player and not player.has_own_account():
-                    lobby.remove_from_lobby(player)
-                    removed.append(player.mention)
+            for p in lobby.get_all_in_lobby():
+                if not p.has_own_account():
+                    lobby.remove_from_lobby(p)
+                    removed.append(p.mention)
             await disp.RM_LOBBY_ACC.send(ContextWrapper.channel(cfg.channels["lobby"]),
                                          ' '.join(removed),
                                          names_in_lobby=lobby.get_all_names_in_lobby())

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -283,7 +283,7 @@ class AdminCog(commands.Cog, name='admin'):
                     lobby.remove_from_lobby(player)
                     removed.append(player.mention)
             await disp.RM_LOBBY_ACC.send(ContextWrapper.channel(cfg.channels["lobby"]),
-                                         ' '.join([p.mention for p in removed]),
+                                         ' '.join(removed),
                                          names_in_lobby=lobby.get_all_names_in_lobby())
             await disp.ACC_ALL_HANDOUT.send(ctx, "disabled")
             return

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -228,10 +228,8 @@ class AdminCog(commands.Cog, name='admin'):
         await player.db_update("timeout")
         await roles.perms_muted(True, player.id)
         if ctx.channel.id != cfg.channels['muted']:
-            await disp.RM_TIMEOUT.send(ctx, player.mention,
-                                       dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
-        await disp.RM_TIMEOUT.send(ContextWrapper.channel(cfg.channels['muted']), player.mention,
-                                   dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
+            await disp.RM_TIMEOUT.send(ctx, player.mention, dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
+        await disp.RM_TIMEOUT.send(ContextWrapper.channel(cfg.channels['muted']), player.mention, dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
 
     @commands.command()
     @commands.guild_only()
@@ -380,15 +378,11 @@ class AdminCog(commands.Cog, name='admin'):
 def setup(client):
     client.add_cog(AdminCog(client))
 
-
 def _log_command(ctx):
     Loop(coro=_log_admin_command_impl, count=1).start(ctx)
 
-
 async def _log_admin_command_impl(ctx):
-    await disp.ADMIN_MSG_LOG.send(ContextWrapper.channel(cfg.channels["spam"]), ctx.author.name, ctx.author.id,
-                                  ctx.message.content, ctx.channel.id)
-
+    await disp.ADMIN_MSG_LOG.send(ContextWrapper.channel(cfg.channels["spam"]), ctx.author.name, ctx.author.id, ctx.message.content, ctx.channel.id)
 
 async def _check_channels(ctx, channels):
     if not isinstance(channels, list):
@@ -397,7 +391,6 @@ async def _check_channels(ctx, channels):
         await disp.WRONG_CHANNEL.send(ctx, ctx.command.name, ", ".join(f"<#{c_id}>" for c_id in channels))
         return False
     return True
-
 
 async def get_check_player(ctx):
     if len(ctx.message.mentions) != 1:

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -228,8 +228,10 @@ class AdminCog(commands.Cog, name='admin'):
         await player.db_update("timeout")
         await roles.perms_muted(True, player.id)
         if ctx.channel.id != cfg.channels['muted']:
-            await disp.RM_TIMEOUT.send(ctx, player.mention, dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
-        await disp.RM_TIMEOUT.send(ContextWrapper.channel(cfg.channels['muted']), player.mention, dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
+            await disp.RM_TIMEOUT.send(ctx, player.mention,
+                                       dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
+        await disp.RM_TIMEOUT.send(ContextWrapper.channel(cfg.channels['muted']), player.mention,
+                                   dt.utcfromtimestamp(end_time).strftime("%Y-%m-%d %H:%M UTC"))
 
     @commands.command()
     @commands.guild_only()
@@ -254,6 +256,38 @@ class AdminCog(commands.Cog, name='admin'):
                 return
             loader.unlock_all(self.client)
             await disp.BOT_UNLOCKED.send(ctx)
+            return
+        await disp.WRONG_USAGE.send(ctx, ctx.command.name)
+
+    @commands.command()
+    @commands.guild_only()
+    async def accounts(self, ctx, *args):
+        if len(args) == 0:
+            await disp.ACC_ALL_HANDOUT.send(ctx, "enabled" if lobby.accounts_enabled() else "disabled")
+            return
+        arg = args[0]
+        if arg == "unlock":
+            if lobby.accounts_enabled():
+                await disp.ACC_ALL_HANDOUT.send(ctx, "already enabled")
+                return
+            lobby.set_lobby_accounts_enabled(True)
+            await disp.ACC_ALL_HANDOUT.send(ctx, "enabled")
+            return
+        if arg == "lock":
+            if not lobby.accounts_enabled():
+                await disp.ACC_ALL_HANDOUT.send(ctx, "already disabled")
+                return
+            lobby.set_lobby_accounts_enabled(False)
+            removed = []
+            for p_id in lobby.get_all_ids_in_lobby():
+                player = Player.get(p_id)
+                if player and not player.has_own_account():
+                    lobby.remove_from_lobby(player)
+                    removed.append(player.mention)
+            await disp.RM_LOBBY_ACC.send(ContextWrapper.channel(cfg.channels["lobby"]),
+                                         ' '.join([p.mention for p in removed]),
+                                         names_in_lobby=lobby.get_all_names_in_lobby())
+            await disp.ACC_ALL_HANDOUT.send(ctx, "disabled")
             return
         await disp.WRONG_USAGE.send(ctx, ctx.command.name)
 
@@ -346,11 +380,15 @@ class AdminCog(commands.Cog, name='admin'):
 def setup(client):
     client.add_cog(AdminCog(client))
 
+
 def _log_command(ctx):
     Loop(coro=_log_admin_command_impl, count=1).start(ctx)
 
+
 async def _log_admin_command_impl(ctx):
-    await disp.ADMIN_MSG_LOG.send(ContextWrapper.channel(cfg.channels["spam"]), ctx.author.name, ctx.author.id, ctx.message.content, ctx.channel.id)
+    await disp.ADMIN_MSG_LOG.send(ContextWrapper.channel(cfg.channels["spam"]), ctx.author.name, ctx.author.id,
+                                  ctx.message.content, ctx.channel.id)
+
 
 async def _check_channels(ctx, channels):
     if not isinstance(channels, list):
@@ -359,6 +397,7 @@ async def _check_channels(ctx, channels):
         await disp.WRONG_CHANNEL.send(ctx, ctx.command.name, ", ".join(f"<#{c_id}>" for c_id in channels))
         return False
     return True
+
 
 async def get_check_player(ctx):
     if len(ctx.message.mentions) != 1:

--- a/bot/cogs/lobby.py
+++ b/bot/cogs/lobby.py
@@ -57,6 +57,9 @@ class LobbyCog(commands.Cog, name='lobby'):
         if player.match:
             await disp.LB_IN_MATCH.send(ctx)
             return
+        if not lobby.accounts_enabled() and not player.has_own_account():
+            await disp.ACC_ALL_DISABLED.send(ctx)
+            return
 
         time = await check_time(ctx, args)
         if time < 0:

--- a/bot/display/embeds.py
+++ b/bot/display/embeds.py
@@ -79,6 +79,7 @@ def admin_help(ctx):
                     value='`=channel (un)freeze` - Prevent users from typing in a channel\n'
                           '`=pog version` - Display current version and lock status\n'
                           '`=pog (un)lock` - Prevent users from interacting with the bot (but admins still can)\n'
+                          '`=accounts (un)lock` - Prevent the usage of POG Account block\n'
                           '`=reload accounts`/`bases`/`weapons`/`config` - Reload specified element from the database\n'
                           '`=spam clear` - Clear the spam filter\n',
                     inline=False)

--- a/bot/display/strings.py
+++ b/bot/display/strings.py
@@ -211,6 +211,10 @@ class AllStrings(Enum):
                          "account to staff instead.")
     ACC_LOG = Message("Player [name:{}], [id:{}] will receive {}")
     ACC_GIVING = Message("Sent a Jaeger account for {}!", ping=False)
+    ACC_ALL_HANDOUT = Message("POG Account Handout {}!")
+    ACC_ALL_DISABLED = Message("POG Account Handout is currently disabled, you must be registered with a personal "
+                               "Jaeger account to join the lobby!")
+
 
     NO_DATA = Message("No data for this id!")
     ACCOUNT_USAGE = Message("Here is the POG account usage for this user:", embed=embeds.usage)
@@ -230,6 +234,8 @@ class AllStrings(Enum):
     RM_OK = Message("Player successfully removed from the system!")
     RM_IN_MATCH = Message("Can't remove a player who is in match!")
     RM_LOBBY = Message("{} have been removed by staff!", embed=embeds.lobby_list)
+    RM_LOBBY_ACC = Message("POG Account usage has been disabled, the following player(s) without a registered Jaeger "
+                           "Account have been removed: {}", embed=embeds.lobby_list)
     RM_QUIT = Message("{} have been removed for quitting!", embed=embeds.lobby_list)
     RM_NOT_LOBBIED = Message("This player is not in queue!")
     RM_TIMEOUT = Message("{} will be muted from POG until {}!", ping=False)

--- a/bot/modules/lobby.py
+++ b/bot/modules/lobby.py
@@ -151,6 +151,9 @@ def get_all_ids_in_lobby():
     ids = [p.id for p in _lobby_list]
     return ids
 
+def get_all_in_lobby():
+    return _lobby_list.copy()
+
 
 def remove_from_lobby(player):
     _remove_from_warned(player)

--- a/bot/modules/lobby.py
+++ b/bot/modules/lobby.py
@@ -11,6 +11,7 @@ log = getLogger("pog_bot")
 
 _lobby_list = list()
 _lobby_stuck = False
+_lobby_accounts_enabled = True
 _MatchClass = None
 _client = None
 _warned_players = dict()
@@ -55,6 +56,13 @@ def _add_ih_callback(ih, player):
             await disp.LB_REFRESH_NO.send(i_ctx)
             raise interactions.InteractionNotAllowed
 
+
+def accounts_enabled():
+    return _lobby_accounts_enabled
+
+def set_lobby_accounts_enabled(bl):
+    global _lobby_accounts_enabled
+    _lobby_accounts_enabled = bl
 
 def is_lobby_stuck():
     return _lobby_stuck


### PR DESCRIPTION
Adds an admin command to un(lock) the usage of the POG Account block.  For use during password flips or other times of unavailability for the POG accounts, while leaving the functionality of the bot open for players who still have access to their accounts.  

Using this command to lock accounts will also prevent users without registered Jaeger accounts from joinining the lobby, and remove such players already in the lobby.