### PR TITLE
add force start command and add Veridad Pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ doc/build/
 .pdm.toml
 __pypackages__
 .pdm-python
+pdm.py

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -269,7 +269,7 @@ class AdminCog(commands.Cog, name='admin'):
             return
 
         # TODO: is this check needed? can you successfully have a 5v6 lobby?
-        if (lobby.get_lobby_len() % 2 != 0):
+        if lobby.get_lobby_len() % 2 != 0:
             await disp.LB_FORCE_START_NOT_EVEN.send(ctx)
             return
 

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -259,6 +259,26 @@ class AdminCog(commands.Cog, name='admin'):
 
     @commands.command()
     @commands.guild_only()
+    async def fstart(self, ctx, *args):
+        if ctx.channel.id != cfg.channels["lobby"]: # only allowed in lobby channel
+            await disp.WRONG_CHANNEL_2.send(ctx, ctx.command.name, f"<#{ctx.channel.id}>")
+            return
+
+        if (lobby.get_lobby_len() == 0): # don't allow starting with 0 players
+            await disp.LB_FORCE_START_ZERO_PLAYERS.send(ctx)
+            return
+
+        # TODO: is this check needed? can you successfully have a 5v6 lobby?
+        if (lobby.get_lobby_len() % 2 != 0):
+            await disp.LB_FORCE_START_NOT_EVEN.send(ctx)
+            return
+
+        # start the match!
+        lobby._start_match_from_full_lobby()
+        await disp.LB_FORCE_START.send(ctx, f"<@{ctx.author.id}>")
+
+    @commands.command()
+    @commands.guild_only()
     async def accounts(self, ctx, *args):
         if len(args) == 0:
             await disp.ACC_ALL_HANDOUT.send(ctx, "enabled" if lobby.accounts_enabled() else "disabled")

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -264,7 +264,7 @@ class AdminCog(commands.Cog, name='admin'):
             await disp.WRONG_CHANNEL_2.send(ctx, ctx.command.name, f"<#{ctx.channel.id}>")
             return
 
-        if (lobby.get_lobby_len() == 0): # don't allow starting with 0 players
+        if lobby.get_lobby_len() == 0: # don't allow starting with 0 players
             await disp.LB_FORCE_START_ZERO_PLAYERS.send(ctx)
             return
 

--- a/bot/config_template.cfg
+++ b/bot/config_template.cfg
@@ -77,3 +77,4 @@ kessel = # Link to base image
 nettlemire = # Link to base image
 bridgewater = # Link to base image
 rime = # Link to base image
+veridad_pass = # link to base image

--- a/bot/display/strings.py
+++ b/bot/display/strings.py
@@ -55,6 +55,9 @@ class AllStrings(Enum):
     LB_TIME_TOO_SHORT = Message("Minimum timeout is 5 minutes!")
     LB_TIME_TOO_LONG = Message("Maximum timeout is 1 hour!")
     LB_TIMEOUT_OK = Message("Lobby timeout updated!", embed=embeds.lobby_list)
+    LB_FORCE_START = Message("Lobby force started by {}")
+    LB_FORCE_START_ZERO_PLAYERS = Message("There are 0 players in lobby, cannot force start")
+    LB_FORCE_START_NOT_EVEN = Message("There are not an even number of players in lobby")
 
     PK_OVER = Message("The teams are already made. You can't pick!")
     PK_NO_LOBBIED = Message("You must first queue and wait for a match to begin. Check <#{}>")

--- a/bot/match/classes/match.py
+++ b/bot/match/classes/match.py
@@ -134,6 +134,9 @@ class Match:
     def spin_up(self, p_list):
         if not self.__objects:
             raise AttributeError("Match instance is not bound, no attribute 'spin_up'")
+        if (Match._last_match_id == None): # if there was no last match, make sure it exists
+            Match._last_match_id = 0
+            db.set_element("restart_data", 0, {"_id": 0, "last_match_id": Match._last_match_id})
         Match._last_match_id += 1
         self.__objects.on_spin_up(p_list)
         db.set_field("restart_data", 0, {"last_match_id": Match._last_match_id})

--- a/bot/match/classes/match.py
+++ b/bot/match/classes/match.py
@@ -134,7 +134,7 @@ class Match:
     def spin_up(self, p_list):
         if not self.__objects:
             raise AttributeError("Match instance is not bound, no attribute 'spin_up'")
-        if (Match._last_match_id == None): # if there was no last match, make sure it exists
+        if Match._last_match_id is None: # if there was no last match, make sure it exists
             Match._last_match_id = 0
             db.set_element("restart_data", 0, {"_id": 0, "last_match_id": Match._last_match_id})
         Match._last_match_id += 1

--- a/bot/match/processes/captain_selection.py
+++ b/bot/match/processes/captain_selection.py
@@ -18,7 +18,6 @@ import match.classes.interactions as interactions
 
 log = getLogger("pog_bot")
 
-
 class CaptainSelection(Process, status=MatchStatus.IS_CAPTAIN):
 
     def __init__(self, match, p_list):

--- a/bot/match/processes/player_picking.py
+++ b/bot/match/processes/player_picking.py
@@ -10,6 +10,8 @@ from match.classes import BaseSelector
 
 import match.classes.interactions as interactions
 
+from logging import getLogger
+log = getLogger("pog_bot")
 
 class PlayerPicking(Process, status=MatchStatus.IS_PICKING):
 
@@ -50,10 +52,15 @@ class PlayerPicking(Process, status=MatchStatus.IS_PICKING):
         """ Init the match channel, ping players, find two captains \
             and ask them to start picking players.
         """
-        # Ready for players to pick
-        ctx = self.interaction_handler.get_new_context(self.match.channel)
-        await disp.MATCH_SHOW_PICKS.send(ctx, self.match.teams[0].captain.mention,
-                                         match=self.match.proxy)
+
+        if (len(self.players) == 0):
+            log.debug(f"there are 0 players, meaning this is a 2 person lobby with 2 captains already!")
+            self.pick_check(None) # normally passing None here is an error, but cause there will be 0 players, it's fine!
+        else:
+            # Ready for players to pick
+            ctx = self.interaction_handler.get_new_context(self.match.channel)
+            await disp.MATCH_SHOW_PICKS.send(ctx, self.match.teams[0].captain.mention,
+                                            match=self.match.proxy)
 
     @property
     def picking_captain(self):

--- a/bot/match/processes/player_picking.py
+++ b/bot/match/processes/player_picking.py
@@ -53,7 +53,7 @@ class PlayerPicking(Process, status=MatchStatus.IS_PICKING):
             and ask them to start picking players.
         """
 
-        if (len(self.players) == 0):
+        if not self.players:
             log.debug(f"there are 0 players, meaning this is a 2 person lobby with 2 captains already!")
             self.pick_check(None) # normally passing None here is an error, but cause there will be 0 players, it's fine!
         else:

--- a/bot/modules/config.py
+++ b/bot/modules/config.py
@@ -77,7 +77,7 @@ loadout_id = {
     21: "max"
 }
 
-# http://census.daybreakgames.com/get/ps2/base_region/?c:limit=400&c:show=facility_id,facility_name,zone_id,facility_type_id
+# http://census.daybreakgames.com/get/ps2:v2/map_region/?c:limit=4000&c:show=facility_id,facility_name,zone_id,facility_type_id
 #: Dictionary to retrieve base id from name.
 base_to_id = {
     "acan": 302030,
@@ -92,7 +92,8 @@ base_to_id = {
     "kessel": 266000,
     "nettlemire": 283000,
     "bridgewater": 272000,
-    "rime": 244610
+    "rime": 244610,
+    "veridad_pass": 400404
 }
 
 #: Dictionary to retrieve base name from id.

--- a/bot/modules/database.py
+++ b/bot/modules/database.py
@@ -121,7 +121,7 @@ def push_element(collection: str, e_id: int, doc: dict):
     if _collections[collection].count_documents({"_id": e_id}) != 0:
         _collections[collection].update_one({"_id": e_id}, {"$push": doc})
     else:
-        raise DatabaseError(f"set_field: Element {e_id} doesn't exist in collection {collection}")
+        raise DatabaseError(f"push_element: Element {e_id} doesn't exist in collection {collection}")
 
 
 def get_element(collection: str, item_id: int) -> (dict, None):

--- a/bot/modules/jaeger_calendar.py
+++ b/bot/modules/jaeger_calendar.py
@@ -23,7 +23,7 @@ def get_booked_bases(base_class, booked_bases_list):  # runs on class init, save
     index_start = index_end = None
     gc = service_account(filename=_secret_file)
 
-    if (cfg.database["jaeger_cal"] is None or cfg.database["jaeger_cal"] == ""):
+    if cfg.database["jaeger_cal"] is None or cfg.database["jaeger_cal"] == "":
         log.info("config value 'jaeger_cal' is not set, skipping booked bases check")
         return
 

--- a/bot/modules/jaeger_calendar.py
+++ b/bot/modules/jaeger_calendar.py
@@ -23,7 +23,7 @@ def get_booked_bases(base_class, booked_bases_list):  # runs on class init, save
     index_start = index_end = None
     gc = service_account(filename=_secret_file)
 
-    if cfg.database["jaeger_cal"] is None or cfg.database["jaeger_cal"] == "":
+    if not cfg.database["jaeger_cal"]:
         log.warning("config value 'jaeger_cal' is not set, skipping booked bases check")
         return
 

--- a/bot/modules/jaeger_calendar.py
+++ b/bot/modules/jaeger_calendar.py
@@ -22,6 +22,11 @@ def init(secret_file):
 def get_booked_bases(base_class, booked_bases_list):  # runs on class init, saves a list of booked bases at the time of init to self.booked
     index_start = index_end = None
     gc = service_account(filename=_secret_file)
+
+    if (cfg.database["jaeger_cal"] is None or cfg.database["jaeger_cal"] == ""):
+        log.info("config value 'jaeger_cal' is not set, skipping booked bases check")
+        return
+
     sh = gc.open_by_key(cfg.database["jaeger_cal"])
     ws = sh.worksheet("Current")
     cal_export = np_array(ws.get_all_values())

--- a/bot/modules/jaeger_calendar.py
+++ b/bot/modules/jaeger_calendar.py
@@ -24,7 +24,7 @@ def get_booked_bases(base_class, booked_bases_list):  # runs on class init, save
     gc = service_account(filename=_secret_file)
 
     if cfg.database["jaeger_cal"] is None or cfg.database["jaeger_cal"] == "":
-        log.info("config value 'jaeger_cal' is not set, skipping booked bases check")
+        log.warning("config value 'jaeger_cal' is not set, skipping booked bases check")
         return
 
     sh = gc.open_by_key(cfg.database["jaeger_cal"])

--- a/bot/scripts.py
+++ b/bot/scripts.py
@@ -137,6 +137,6 @@ def fill_player_stats():
     db.force_update("player_stats", la)
 
 if __name__ == "__main__":
-    push_accounts_to_usage()
+    #push_accounts_to_usage()
     #push_accounts_to_users()
-    #get_all_bases_from_api()
+    get_all_bases_from_api()

--- a/bot/template_test_file.py
+++ b/bot/template_test_file.py
@@ -21,9 +21,9 @@ bot = None
 def get_ids():
     # Enter here a list of discord IDS of accounts you wish to use for the testing
     # For example:
-    # return [0000, 0000, 0000, 0000]
-    from test import ids
-    return ids
+    return [0000, 0000, 0000, 0000]
+    #from test import ids
+    #return ids
 
 
 def test_hand(client):


### PR DESCRIPTION
full changes:

add Veridad Pass to the map pool.

add a `=fstart` command for admins to start lobbies that have less than the number of players needed to start.

fix crash on lobby start if the Mongo collection `restart_data` is empty.

fix 2 player lobbies not starting due to the player picker not showing any players (instead just goes to faction select).

fix lobbies not starting if no jaeger calendar ID is given.